### PR TITLE
Add tracking of lost messages.  Fix filter mask parameter in begin().

### DIFF
--- a/FlexCAN.cpp
+++ b/FlexCAN.cpp
@@ -399,6 +399,7 @@ int FlexCAN::read(CAN_message_t &msg)
 {
     if (rx_buffer_head == rx_buffer_tail) return 0;
     msg.id = rx_frame_buff[rx_buffer_tail].id;
+    msg.timestamp = rx_frame_buff[rx_buffer_tail].timestamp;
     msg.ext = rx_frame_buff[rx_buffer_tail].ext;
     msg.len = rx_frame_buff[rx_buffer_tail].len;
     msg.rtr = rx_frame_buff[rx_buffer_tail].rtr;
@@ -493,8 +494,10 @@ void FlexCAN::readRxRegisters(CAN_message_t& msg, uint8_t buffer)
   msg.len = FLEXCAN_get_length(FLEXCANb_MBn_CS(flexcanBase, buffer));
   msg.ext = (FLEXCANb_MBn_CS(flexcanBase, buffer) & FLEXCAN_MB_CS_IDE)? 1:0;
   msg.rtr = (FLEXCANb_MBn_CS(flexcanBase, buffer) & FLEXCAN_MB_CS_RTR)? 1:0;
+  msg.timestamp = FLEXCAN_get_timestamp(FLEXCANb_MBn_CS(flexcanBase, buffer));
   msg.flags.overrun = 0;
   msg.flags.reserved = 0;
+
   msg.id  = (FLEXCANb_MBn_ID(flexcanBase, buffer) & FLEXCAN_MB_ID_EXT_MASK);
   if(!msg.ext) {
     msg.id >>= FLEXCAN_MB_ID_STD_BIT_NO;

--- a/FlexCAN.h
+++ b/FlexCAN.h
@@ -16,7 +16,7 @@
 
 typedef struct CAN_message_t {
   uint32_t id;          // can identifier
-  uint16_t timeout;     // milliseconds, zero will disable waiting
+  uint16_t timestamp;   // FlexCAN time when message arrived
   struct {
     uint8_t extended:1; // identifier is extended (29-bit)
     uint8_t remote:1;   // remote transmission request packet type

--- a/FlexCAN.h
+++ b/FlexCAN.h
@@ -8,11 +8,13 @@
 
 #include <Arduino.h>
 
-#define SIZE_RX_BUFFER  32 //RX incoming ring buffer size
+#define SIZE_RX_BUFFER  48 //RX incoming ring buffer size
 #define SIZE_TX_BUFFER  16 //TX ring buffer size
 #define SIZE_LISTENERS  4  //number of classes that can register as listeners on each CAN bus
 #define NUM_MAILBOXES   16 //architecture specific but all Teensy 3.x boards have 16 mailboxes
 #define IRQ_PRIORITY    64 //0 = highest, 255 = lowest
+
+#define COLLECT_CAN_STATS
 
 typedef struct CAN_message_t {
   uint32_t id;          // can identifier
@@ -36,6 +38,21 @@ typedef struct CAN_filter_t {
   } flags;
 } CAN_filter_t;
 
+// statistics about the CAN interface
+
+typedef struct CAN_stats_t {
+  bool     enabled;           // enable collecting statistics
+  uint32_t ringRxMax;         // number of entries in the ring buffer
+  uint32_t ringRxHighWater;   // maximum entries used in the ring buffer
+  uint32_t ringRxFramesLost;  // total number of frames lost
+  uint32_t ringTxMax;         // number of entries in the ring buffer
+  uint32_t ringTxHighWater;   // maximum entries used in the ring buffer
+  struct {
+    uint32_t refCount;        // mailbox reference (use) count
+    uint32_t overrunCount;    // mailbox message overrun count
+  } mb[NUM_MAILBOXES];
+} CAN_stats_t;
+
 // for backwards compatibility with previous structure members
 
 #define	ext flags.extended
@@ -45,18 +62,18 @@ class CANListener
 {
 public:
   CANListener();
-    
+
   virtual void gotFrame(CAN_message_t &frame, int mailbox);
 
   void attachMBHandler(uint8_t mailBox);
   void detachMBHandler(uint8_t mailBox);
   void attachGeneralHandler();
   void detachGeneralHandler();
-    
+
 private:
   int callbacksActive; //bitfield letting the code know which callbacks to actually try to use (for object oriented callbacks only)
-    
-  friend class FlexCAN; //class has to have access to the the guts of this one 
+
+  friend class FlexCAN; //class has to have access to the the guts of this one
 };
 
 // -------------------------------------------------------------
@@ -70,12 +87,16 @@ private:
   volatile CAN_message_t tx_frame_buff[SIZE_TX_BUFFER];
   volatile uint16_t rx_buffer_head, rx_buffer_tail;
   volatile uint16_t tx_buffer_head, tx_buffer_tail;
-  uint32_t rxBufferFramesLost;
   void mailbox_int_handler(uint8_t mb, uint32_t ul_status);
   CANListener *listener[SIZE_LISTENERS];
 
   void writeTxRegisters(const CAN_message_t &msg, uint8_t buffer);
   void readRxRegisters(CAN_message_t &msg, uint8_t buffer);
+
+#ifdef COLLECT_CAN_STATS
+  CAN_stats_t stats;
+#endif
+
 protected:
   uint8_t numTxMailboxes;
 
@@ -89,21 +110,28 @@ public:
   int available(void);
   int write(const CAN_message_t &msg);
   int read(CAN_message_t &msg);
-  uint32_t rxBufferOverruns(void) { return rxBufferFramesLost; };
-  
+  uint32_t rxBufferOverruns(void) { return stats.ringRxFramesLost; };
+
+#ifdef COLLECT_CAN_STATS
+  void startStats(void) { stats.enabled = true; };
+  void stopStats(void) { stats.enabled = false; };
+  void clearStats(void);
+  CAN_stats_t getStats(void) { return stats; };
+#endif
+
   //new functionality added to header but not yet implemented. Fix me
   void setListenOnly(bool mode); //pass true to go into listen only mode, false to be in normal mode
 
   boolean attachObj(CANListener *listener);
   boolean detachObj(CANListener *listener);
-  
+
   //int watchFor(); //allow anything through
   //int watchFor(uint32_t id); //allow just this ID through (automatic determination of extended status)
   //int watchFor(uint32_t id, uint32_t mask); //allow a range of ids through
   //int watchForRange(uint32_t id1, uint32_t id2); //try to allow the range from id1 to id2 - automatically determine base ID and mask
 
   int setNumTXBoxes(int txboxes);
-  
+
   void message_isr(void);
   void bus_off_isr(void);
   void error_isr(void);

--- a/kinetis_flexcan.h
+++ b/kinetis_flexcan.h
@@ -507,6 +507,7 @@ typedef volatile uint32_t vuint32_t;
 #define FLEXCAN_MB_CODE_TX_RESPONSE_TEMPO	(0x0E)
 #define FLEXCAN_get_code(cs)				(((cs) & FLEXCAN_MB_CS_CODE_MASK)>>24)
 #define FLEXCAN_get_length(cs)             (((cs) & FLEXCAN_MB_CS_DLC_MASK)>>16)
+#define FLEXCAN_get_timestamp(cs)             (((cs) & FLEXCAN_MB_CS_TIMESTAMP_MASK)>>0)
 
 /* Bit definitions and macros for FLEXCAN_MB_ID */
 #define FLEXCAN_MB_ID_STD_MASK		   (0x1FFC0000L)


### PR DESCRIPTION
This update adds some additional fields to the CAN_message_t structure to allow the interrupt handler to flag that the mailbox the message came from had an overflow condition.   Messages with the overrun bit set have overwritten another message.

The ring buffer insertion code also keeps track of the number of messages that have been discarded due to the ring buffer being full.  The method rxBufferOverruns() will return the discard count.

The begin() method doesn't currently use the supplied filter mask, it uses a built-in version instead.  The code is updated to properly handle the supplied mask.