### PR TITLE
Re-work ring buffer code and code clean-up.

### DIFF
--- a/FlexCAN.cpp
+++ b/FlexCAN.cpp
@@ -337,18 +337,39 @@ int FlexCAN::setNumTXBoxes(int txboxes) {
  */
 void FlexCAN::setFilter(const CAN_filter_t &filter, uint8_t n)
 {
-   if (n < NUM_MAILBOXES - numTxMailboxes)
-   {
-       MBFilters[n] = filter;
-       if (filter.ext)
-       {
-          FLEXCANb_MBn_ID(flexcanBase, n) = (filter.id & FLEXCAN_MB_ID_EXT_MASK);
-          FLEXCANb_MBn_CS(flexcanBase, n) |= FLEXCAN_MB_CS_IDE;
-       } else {
-          FLEXCANb_MBn_ID(flexcanBase, n) = FLEXCAN_MB_ID_IDSTD(filter.id);
-          FLEXCANb_MBn_CS(flexcanBase, n) &= ~FLEXCAN_MB_CS_IDE;
-       }
-   }
+    if (n < NUM_MAILBOXES - numTxMailboxes)
+    {
+        MBFilters[n] = filter;
+        if (filter.ext)
+        {
+           FLEXCANb_MBn_ID(flexcanBase, n) = (filter.id & FLEXCAN_MB_ID_EXT_MASK);
+           FLEXCANb_MBn_CS(flexcanBase, n) |= FLEXCAN_MB_CS_IDE;
+        } else {
+           FLEXCANb_MBn_ID(flexcanBase, n) = FLEXCAN_MB_ID_IDSTD(filter.id);
+           FLEXCANb_MBn_CS(flexcanBase, n) &= ~FLEXCAN_MB_CS_IDE;
+        }
+    }
+}
+
+ /* \brief Gets a per-mailbox filter.
+ *
+ * \param returned filter structure,  mailbox selected
+ *
+ * \retval true if mailbox s valid, false otherwise
+ *
+ */
+bool FlexCAN::getFilter(CAN_filter_t &filter, uint8_t n)
+{
+    if (n < NUM_MAILBOXES - numTxMailboxes)
+    {
+        filter.id = MBFilters[n].id;
+        filter.flags.extended = MBFilters[n].flags.extended;
+        filter.flags.remote = MBFilters[n].flags.remote;
+        filter.flags.reserved = MBFilters[n].flags.reserved;
+        return (true);
+    }
+
+    return (false);
 }
 
 /*

--- a/FlexCAN.h
+++ b/FlexCAN.h
@@ -8,8 +8,14 @@
 
 #include <Arduino.h>
 
-#define SIZE_RX_BUFFER  48 //RX incoming ring buffer size
+#if !defined(SIZE_RX_BUFFER)
+#define SIZE_RX_BUFFER  32 //RX incoming ring buffer size
+#endif
+
+#if !defined(SIZE_TX_BUFFER)
 #define SIZE_TX_BUFFER  16 //TX ring buffer size
+#endif
+
 #define SIZE_LISTENERS  4  //number of classes that can register as listeners on each CAN bus
 #define NUM_MAILBOXES   16 //architecture specific but all Teensy 3.x boards have 16 mailboxes
 #define IRQ_PRIORITY    64 //0 = highest, 255 = lowest
@@ -53,6 +59,15 @@ typedef struct CAN_stats_t {
   } mb[NUM_MAILBOXES];
 } CAN_stats_t;
 
+// ring buffer data structure
+
+typedef struct ringbuffer_t {
+  volatile uint16_t head;
+  volatile uint16_t tail;
+  uint16_t size;
+  volatile CAN_message_t *buffer;
+} ringbuffer_t;
+
 // for backwards compatibility with previous structure members
 
 #define	ext flags.extended
@@ -83,15 +98,22 @@ private:
   uint32_t flexcanBase;
   struct CAN_filter_t MBFilters[NUM_MAILBOXES];
   static struct CAN_filter_t defaultMask;
-  volatile CAN_message_t rx_frame_buff[SIZE_RX_BUFFER];
-  volatile CAN_message_t tx_frame_buff[SIZE_TX_BUFFER];
-  volatile uint16_t rx_buffer_head, rx_buffer_tail;
-  volatile uint16_t tx_buffer_head, tx_buffer_tail;
   void mailbox_int_handler(uint8_t mb, uint32_t ul_status);
   CANListener *listener[SIZE_LISTENERS];
 
-  void writeTxRegisters(const CAN_message_t &msg, uint8_t buffer);
-  void readRxRegisters(CAN_message_t &msg, uint8_t buffer);
+  ringbuffer_t txRing;
+  volatile CAN_message_t tx_buffer[SIZE_TX_BUFFER];
+  ringbuffer_t rxRing;
+  volatile CAN_message_t rx_buffer[SIZE_RX_BUFFER];
+
+  void writeTxRegisters (const CAN_message_t &msg, uint8_t buffer);
+  void readRxRegisters (CAN_message_t &msg, uint8_t buffer);
+
+  void initRingBuffer (ringbuffer_t &ring, volatile CAN_message_t *buffer, uint32_t size);
+  bool addToRingBuffer (ringbuffer_t &ring, const CAN_message_t &msg);
+  bool removeFromRingBuffer (ringbuffer_t &ring, CAN_message_t &msg);
+  bool isRingBufferEmpty (ringbuffer_t &ring);
+  uint32_t ringBufferCount (ringbuffer_t &ring);
 
 #ifdef COLLECT_CAN_STATS
   CAN_stats_t stats;
@@ -123,15 +145,15 @@ public:
   //new functionality added to header but not yet implemented. Fix me
   void setListenOnly(bool mode); //pass true to go into listen only mode, false to be in normal mode
 
-  boolean attachObj(CANListener *listener);
-  boolean detachObj(CANListener *listener);
+  bool attachObj(CANListener *listener);
+  bool detachObj(CANListener *listener);
 
   //int watchFor(); //allow anything through
   //int watchFor(uint32_t id); //allow just this ID through (automatic determination of extended status)
   //int watchFor(uint32_t id, uint32_t mask); //allow a range of ids through
   //int watchForRange(uint32_t id1, uint32_t id2); //try to allow the range from id1 to id2 - automatically determine base ID and mask
 
-  int setNumTXBoxes(int txboxes);
+  int setNumTxBoxes(int txboxes);
 
   void message_isr(void);
   void bus_off_isr(void);

--- a/FlexCAN.h
+++ b/FlexCAN.h
@@ -105,6 +105,7 @@ public:
   void begin(uint32_t baud = 250000, const CAN_filter_t &mask = defaultMask, uint8_t txAlt = 0, uint8_t rxAlt = 0);
 
   void setFilter(const CAN_filter_t &filter, uint8_t n);
+  bool getFilter(CAN_filter_t &filter, uint8_t n);
   void setMask(uint32_t mask, uint8_t n);
   void end(void);
   int available(void);

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Returns 0 if no frames are available. Otherwise returns the number of available 
 | timestamp       | Hardware based timestamp       | Hardware generated timestamp when frame was received (on RX frames)
 | buf             | Data bytes for this frame      | Anything. These 0 to 8 bytes are the payload of the frame.
 
-**setNumTXBoxes(boxes)**
+**setNumTxBoxes(boxes)**
 Set the number of mailboxes used for transmit. There are 16 mailboxes in hardware. 0 to 16 of them can be set as transmission mailboxes. These mailboxes will then not be used for reception. By default, two mailboxes are automatically configured for transmission.
  
 ###Use of Optional RX Filtering
@@ -100,7 +100,12 @@ The mask and filter are **CAN_filter_t** type structures.
 Set the receive mask for the selected mailbox. Cannot be used on transmission mailboxes (The last two by default). Used along with filters to configure which messages will be accepted by each mailbox. The filtering scheme works like this: When a frame comes in the ID of the frame has a boolean AND applied with the mask for the mailbox. Then, this masked value is compared to the filter ID. If the two match then the frame is accepted. If not the next mailbox is checked. If no mailboxes accept a frame it is thrown away. Here is an example: Mask of 0x7F0, filter ID of 0x320. If a frame with id 0x322 comes in then 0x322 AND 0x7F0 = 0x320. This matches so the frame is accepted. If a frame comes in with id 0x33B then 0x33B AND 0x7F0 = 0x330 which does not match. Unless another mailbox accepts the frame it will be thrown away.
 
 ###In-order Transmission
-By default two transmission mailboxes are configured. Ordinarily two mailboxes still allow for in-order transmission as they'll ping-pong while loading frames and send them out in order on the bus. However, there are still some scenarios where it might be possible for both mailboxes to get loaded and the wrong frame to go out causing a single frame out of order situation. For strict in-order transmission the library should be set to use a single transmission box like so: **Can0.setNumTXBoxes(1);**
+By default two transmission mailboxes are configured. Ordinarily two mailboxes still allow for in-order transmission as they'll ping-pong while loading frames and send them out in order on the bus. However, there are still some scenarios where it might be possible for both mailboxes to get loaded and the wrong frame to go out causing a single frame out of order situation. For strict in-order transmission the library should be set to use a single transmission box like so: **Can0.setNumTxBoxes(1);**
+
+###Out of Order Reception
+The driver configuration uses multiple mailboxes to receive the incoming messages.  The FlexCAN hardware sequentially searches the configured mailboxes for an empty mailbox, an incoming message is stored in the first empty mailbox found.  As messages are copied from the FlexCAN mailboxes to the incoming ring buffer, the driver sequentially clears the mailboxes. This creates the possibility that the FlexCAN hardware may fill the mailboxes out of order; a recently cleared mailbox may be filled along with a mailbox following the already filled mailboxes.
+
+This may result in messages being delivered out of order by the **read()** function.  The timestamp within the message will correctly indicate the time of arrival and should be used to order the messages.
 
 ###CAN Bus Statistics
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ Set the number of mailboxes used for transmit. There are 16 mailboxes in hardwar
  
 ###Use of Optional RX Filtering
 **setFilter(filter, number)**
-Set the receive filter selected by number, 0-15. There are 16 mailboxes in hardware but 2 are used, by default, for TX. Those cannot have filters set. Otherwise, each mailbox has its own filter and mask. The transmit boxes are always at the end. So, by default they are 14 and 15. Filters take the form of a CAN bus ID (11 bit or 29 bit).
+Set the receive filter selected by "number", 0-15. There are 16 mailboxes in hardware but 2 are used, by default, for TX. Those cannot have filters set. Otherwise, each mailbox has its own filter and mask. The transmit boxes are always at the end. So, by default they are 14 and 15. Filters take the form of a CAN bus ID (11 bit or 29 bit).
+
+**getFilter(filter, number)**
+Retrieve the mailbox filter selected by "number", 0-15.  If the mailbox has a filter, true is returned, otherwise false is returned.  The filter is returned in the parameter "filter".
 
 The mask and filter are **CAN_filter_t** type structures.
 


### PR DESCRIPTION
The ring buffer code did not handle more than 256 entries, it now handles up to 64K entries.  A ring buffer API has been created to reduce code duplication and to aid in code clarity.

General code and comment clean-up to make the file use a consistent formatting.

With a large receive ring buffer (1024 entries), Teensy 3.6 can now keep up with a saturated 1Mbit CAN channel while writing the data to a file on the SD card. 