### PR TITLE
Fix for reading extended frames without filters 

### DIFF
--- a/FlexCAN.cpp
+++ b/FlexCAN.cpp
@@ -218,7 +218,7 @@ void FlexCAN::begin (uint32_t baud, const CAN_filter_t &mask, uint8_t txAlt, uin
     setBaudRate(baud);
 
     // need to modify CTRL2 to allow extended frames, even if global mailbox filter is unused
-    FLEXCANb_CTRL2(flexcanBase) = (BIT16); 
+    FLEXCANb_CTRL2(flexcanBase) |= (BIT16); 
 
     // enable per-mailbox filtering
 

--- a/FlexCAN.cpp
+++ b/FlexCAN.cpp
@@ -22,6 +22,7 @@
 #define FLEXCANb_IDFLT_TAB(b, n)          (*(vuint32_t*)(b+0xE0+(n*4)))
 #define FLEXCANb_MB_MASK(b, n)            (*(vuint32_t*)(b+0x880+(n*4)))
 #define FLEXCANb_ESR1(b)                  (*(vuint32_t*)(b+0x20))
+#define FLEXCANb_CTRL2(b)                 (*(vuint32_t*)(b+0x34))
 
 #if defined(__MK66FX1M0__)
 # define INCLUDE_FLEXCAN_CAN1
@@ -215,6 +216,9 @@ void FlexCAN::begin (uint32_t baud, const CAN_filter_t &mask, uint8_t txAlt, uin
     FLEXCANb_MCR (flexcanBase) |= FLEXCAN_MCR_SRX_DIS;
 
     setBaudRate(baud);
+
+    // need to modify CTRL2 to allow extended frames, even if global mailbox filter is unused
+    FLEXCANb_CTRL2(flexcanBase) = (BIT16); 
 
     // enable per-mailbox filtering
 


### PR DESCRIPTION
Was unable to receive extended CAN frames, with the existing initialization and default filter masking. 

The MK66 datasheet, page 1749, footnote three indicates that unless EACEN is set to 1, we won't be able to pass extended frames.  

"If the CTRL2[EACEN] bit is negated, the IDE bit of Mailbox is always compared with the IDE bit of the incoming frame." 

The assignment of default masking for each MB is 0, only standard IDs may pass. Setting CTRL2[EACEN] to 1 bypasses this comparison problem and allows standard and extended IDs through with the default masking scheme, as I believe is intended. 

I tested this transmitting and receiving both extended and standard IDs. Before this change, only standard IDs would pass, after both standard and extended IDs would pass. I did not test any message filtering with specific mailboxes. 